### PR TITLE
Update uStepper.cpp

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ The uStepper should NOT be connected to the USB port while installing this drive
 This is not a problem for windows/linux users, as these drivers come with the arduino installation.
 
 ## Change Log
+1.3.0:
+- Changed MoveToAngle() function, to support update of angle setpoint in PID mode
+- Changed getMotorState() function, to support update of angle setpoint in PID mode
+- Fixed bug in moveAngle() function, where negative inputs had no effect
+- Changed the "LimitDetection" example to make use of the new moveToEnd() function
+
 1.2.3:
 - Added moveAngle() and MoveToAngle() functions
 - Minor adjustments in setup routines

--- a/src/uStepper.cpp
+++ b/src/uStepper.cpp
@@ -1516,11 +1516,11 @@ void uStepper::moveToAngle(float angle, bool holdMode)
 		
 		if(diff < 0.0)
 		{
-			this->moveSteps(steps, CCW, holdMode);
+			this->moveSteps(steps, CW, holdMode);
 		}
 		else
 		{
-			this->moveSteps(steps, CW, holdMode);
+			this->moveSteps(steps, CCW, holdMode);
 		}
 
 }
@@ -1532,12 +1532,12 @@ void uStepper::moveAngle(float angle, bool holdMode)
 	if(angle < 0.0)
 	{
 		steps = -(int32_t)((angle*angleToStep) - 0.5);
-		this->moveSteps(steps, CCW, holdMode);
+		this->moveSteps(steps, CW, holdMode);
 	}
 	else
 	{
 		steps = (int32_t)((angle*angleToStep) + 0.5);
-		this->moveSteps(steps, CW, holdMode);
+		this->moveSteps(steps, CCW, holdMode);
 	}
 }
 


### PR DESCRIPTION
Direction needs to be reversed to match the `stepper.encoder.getAngleMoved()` output.

```
  stepper.moveAngle(10, HARD);
  Serial.println(stepper.encoder.getAngleMoved()); // -10
```