### PR TITLE
Fixed sense of rotation in moveToAngle, move Angle

### DIFF
--- a/src/uStepper.cpp
+++ b/src/uStepper.cpp
@@ -1516,11 +1516,11 @@ void uStepper::moveToAngle(float angle, bool holdMode)
 		
 		if(diff < 0.0)
 		{
-			this->moveSteps(steps, CCW, holdMode);
+			this->moveSteps(steps, CW, holdMode);
 		}
 		else
 		{
-			this->moveSteps(steps, CW, holdMode);
+			this->moveSteps(steps, CCW, holdMode);
 		}
 
 }
@@ -1532,12 +1532,12 @@ void uStepper::moveAngle(float angle, bool holdMode)
 	if(angle < 0.0)
 	{
 		steps = -(int32_t)((angle*angleToStep) - 0.5);
-		this->moveSteps(steps, CCW, holdMode);
+		this->moveSteps(steps, CW, holdMode);
 	}
 	else
 	{
 		steps = (int32_t)((angle*angleToStep) + 0.5);
-		this->moveSteps(steps, CW, holdMode);
+		this->moveSteps(steps, CCW, holdMode);
 	}
 }
 

--- a/src/uStepper.h
+++ b/src/uStepper.h
@@ -1156,7 +1156,7 @@ public:
 	 * @brief      	Moves the motor to an absolute angle
 	 *
 	 * @param[in]  	angle  Absolute angle. A positive angle makes
-	 *				the motor turn clockwise, and a negative angle, counterclockwise.
+	 *				the motor turn counterclockwise, and a negative angle, clockwise.
 	 *
 	 * @param[in]  	holdMode can be set to "HARD" for brake mode or "SOFT" for
 	 *              freewheel mode (without the quotes).
@@ -1168,7 +1168,7 @@ public:
 	 * @brief      	Moves the motor to a relative angle
 	 *
 	 * @param[in]  	angle  Relative angle from current position. A positive angle makes
-	 *				the motor turn clockwise, and a negative angle, counterclockwise.
+	 *				the motor turn counterclockwise, and a negative angle, clockwise.
 	 *
 	 * @param[in]  	holdMode can be set to "HARD" for brake mode or "SOFT" for
 	 *              freewheel mode (without the quotes).


### PR DESCRIPTION
The internal uStepperEncoder methods count positive angles in CCW direction, yet uStepper's moveToAngle and moveAngle defined positive angles as CW.
For moveAngle this isn't too bad, but moveToAngle was broken by this inconsistency.